### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,3 @@ homepage = "https://github.com/smol-rs/easy-parallel"
 documentation = "https://docs.rs/easy-parallel"
 keywords = ["scope", "thread", "scoped", "spawn"]
 categories = ["concurrency"]
-readme = "README.md"


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.