### PR TITLE
v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 3.3.0
+
+- Add `Parallel::collect()` and `Parallel::finish_in()` to allow for generic containers. (#9)
+
 # Version 3.2.0
 
 - Remove `T: Default` bound from `Default` impl.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "easy-parallel"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.2.0"
+version = "3.3.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.35"


### PR DESCRIPTION
- Add `Parallel::collect()` and `Parallel::finish_in()` to allow for generic containers. (#9)