### PR TITLE
Migrate to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "easy-parallel"
 # - Create "v3.x.y" git tag
 version = "3.3.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.63"
 description = "Run closures in parallel"
 license = "Apache-2.0 OR MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@
 )]
 
 use std::fmt;
-use std::iter::{self, FromIterator};
+use std::iter;
 use std::panic;
 use std::sync::mpsc;
 use std::thread;


### PR DESCRIPTION
Our MSRV (1.63) is higher than 1.56 that Rust 2021 was stabilized.